### PR TITLE
Fix uncapped seconds in game timer after 1 hour

### DIFF
--- a/src/screen_ending.c
+++ b/src/screen_ending.c
@@ -156,7 +156,7 @@ static void screen_ending_format_time(LPWSTR out, int total_seconds)
 {
     int hours = total_seconds / 3600;
     int minutes = total_seconds / 60 - hours * 60;
-    int seconds = total_seconds - minutes * 60;
+    int seconds = total_seconds - minutes * 60 - hours * 3600;
     if (hours > 0) {
         wsprintf(out, L"%d godz %d min %d s", hours, minutes, seconds);
     }

--- a/src/screen_question.c
+++ b/src/screen_question.c
@@ -918,7 +918,7 @@ LRESULT CALLBACK screen_question_wndproc(
         if (instance && total_seconds != instance->timer_seconds) {
             int hours = total_seconds / 3600;
             int minutes = total_seconds / 60 - hours * 60;
-            int seconds = total_seconds - minutes * 60;
+            int seconds = total_seconds - minutes * 60 - hours * 3600;
 
             wsprintf(buffer, L"\tCzas nauki: %02d:%02d:%02d", hours, minutes, seconds);
             SendMessage(instance->status_bar, SB_SETTEXT, 1, (LPARAM)buffer);


### PR DESCRIPTION
When studying for more than 1 hour, the seconds part of the game time timer shows a value above 3600. Here's a simple fix - adding something you might have forgotten :D

![image](https://github.com/swiszczoo/testownik-win32/assets/37554206/038b2478-774c-4712-8942-42e9bccd7576)
